### PR TITLE
Limit labels to 50 characters

### DIFF
--- a/lib/pt_to_github/story.rb
+++ b/lib/pt_to_github/story.rb
@@ -56,7 +56,7 @@ module PtToGithub
 
     def labels
       @labels ||= begin
-        labels = @row[:labels].split(",").map(&:strip)
+        labels = @row[:labels].split(",").map(&:strip).map { |label| label[0, 50] }
 
         labels << type
       end


### PR DESCRIPTION
GitHub issue labels are limited to 50 characters
If they are longer, the API throws a validation failed error. So we will just accept the first 50 characters of the label and throw away the rest.